### PR TITLE
Fix: Glance, Dashboard, Profile, new theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@tanstack/react-query-devtools": "^4.2.1",
         "@tanstack/react-table": "^8.5.11",
         "@tanstack/react-virtual": "^3.0.0-beta.18",
-        "framer-motion": "^6.3.11",
+        "framer-motion": "^6.5.1",
         "luxon": "^3.0.1",
         "prop-types": "^15.8.1",
         "react": "^18.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@tanstack/react-query-devtools": "^4.2.1",
     "@tanstack/react-table": "^8.5.11",
     "@tanstack/react-virtual": "^3.0.0-beta.18",
-    "framer-motion": "^6.3.11",
+    "framer-motion": "^6.5.1",
     "luxon": "^3.0.1",
     "prop-types": "^15.8.1",
     "react": "^18.1.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,40 +1,59 @@
 /* eslint-disable react/jsx-no-constructed-context-values */
+// React
 import React, { useState, useEffect } from 'react';
-import { Box } from '@chakra-ui/react';
-
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Routes, Route } from 'react-router-dom';
 
+// UI
+import { Box } from '@chakra-ui/react';
+
+// React Query
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+// Cookies
 import Cookies from 'universal-cookie';
 
+// API
 import { eventLiveState } from './api/api';
 
+// Context
+import AuthContext from './context/AuthContext';
+import EventContext from './context/EventContext';
+// Navigation
 import Header from './components/Header/Header';
+
+// Views - Dashboard
 import Dashboard from './views/Dashboard/Dashboard';
+import PreEvent from './views/Dashboard/PreEvent';
+import EventEnd from './views/Dashboard/EventEnd';
+import OffSeason from './views/Dashboard/OffSeason';
+
+// Views - Navigation routes
 import Schedule from './views/Schedule/Schedule';
 import Hunting from './views/Hunting/Hunting';
 import Profile from './views/Profile/Profile';
-
-import AuthContext from './context/AuthContext';
-import EventContext from './context/EventContext';
-import EventEnd from './views/Dashboard/EventEnd';
-import PreEvent from './views/Dashboard/PreEvent';
-import Leaderboard from './views/Leaderboard/Leaderboard';
 import Glance from './views/Glance/Glance';
+
+// Views - Leaderboard
+import Leaderboard from './views/Leaderboard/Leaderboard';
 import WRHolders from './views/WRHolders/WRHolders';
 
+// Views - Streamer Info
+import StreamerInfo from './views/StreamerInfo/StreamerInfo';
+
+// Views - Admin
 import AdminIndex from './views/Admin/AdminIndex';
 import EventManager from './views/Admin/EventManager';
 import WRManager from './views/Admin/WRManager';
 import MapManager from './views/Admin/MapManager';
-import StreamerInfo from './views/StreamerInfo/StreamerInfo';
 
 const cookies = new Cookies();
 
 const queryClient = new QueryClient();
 
 const App = () => {
+  const [isSuccess, setIsSuccess] = useState(false);
+
   const [authentication, setAuthentication] = useState({
     isLoggedIn: (cookies.get('token') || '') !== '',
     token: cookies.get('token') || '',
@@ -48,6 +67,21 @@ const App = () => {
     edition: 0,
   });
 
+  const EventSwitcher = ({ event }) => {
+    switch (event.isLive) {
+      case 'active':
+        return <Dashboard />;
+      case 'post':
+        return <EventEnd />;
+      case 'offseason':
+        return <OffSeason />;
+      case 'pre':
+        return <PreEvent />;
+      default:
+        return <PreEvent />;
+    }
+  };
+
   useEffect(() => {
     eventLiveState().then(data => {
       setEvent({
@@ -55,6 +89,7 @@ const App = () => {
         type: (data.type || 'e').toLowerCase(),
         edition: data.edition || '',
       });
+      setIsSuccess(true); // Indicate loading completion
     });
   }, []);
 
@@ -67,15 +102,7 @@ const App = () => {
               <Route path='/' element={<Header>Header</Header>}>
                 <Route
                   index
-                  element={
-                    event.isLive === 'active' ? (
-                      <Dashboard />
-                    ) : event.isLive === 'post' ? (
-                      <EventEnd />
-                    ) : (
-                      <PreEvent />
-                    )
-                  }
+                  element={isSuccess ? <EventSwitcher event={event} /> : null}
                 />
                 <Route path='schedule' element={<Schedule />} />
                 <Route path='hunting' element={<Hunting />} />

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -1,25 +1,33 @@
 import React from 'react';
 import { Box, Link } from '@chakra-ui/react';
+import { motion } from 'framer-motion';
 
-const Footer = () =>
-  <Box mb={5} textTransform='none' fontSize="large">
-    Like this project? Maybe you want to help with&nbsp;
+const Footer = () => (
+  <motion.div
+    initial={{ opacity: 0 }}
+    animate={{ opacity: 1 }}
+    transition={{ duration: 0.5, delay: 1 }}
+  >
+    <Box mb={5} textTransform='none' fontSize='large' py={8}>
+      Like this project? Maybe you want to help with&nbsp;
       <Link
         href='https://github.com/kacky-code/kacky-eventpage-frontend'
         isExternal
-        textDecoration="underline"
+        textDecoration='underline'
       >
-          coding
+        coding
       </Link>
       &nbsp;or&nbsp;
       <Link
         href='https://ko-fi.com/corkscrew'
         isExternal
-        textDecoration="underline"
+        textDecoration='underline'
       >
-          server costs
+        server costs
       </Link>
       ?
-  </Box>
+    </Box>
+  </motion.div>
+);
 
-export default Footer
+export default Footer;

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -30,7 +30,7 @@ import {
 
 import Cookies from 'universal-cookie';
 
-import Footer from '../Footer/Footer'
+import Footer from '../Footer/Footer';
 import KrLogo2023 from '../../assets/logos/krLogo2023';
 import HeaderTab from './HeaderTab';
 import AuthModal from './AuthModal/AuthModal';
@@ -249,12 +249,13 @@ const Header = () => {
       id: 5,
       isSpacer: true,
     },
-    {
-      id: 6,
-      route: '/leaderboard',
-      text: '',
-      TabIcon: MdOutlineLeaderboard,
-    },
+    // {
+    //   id: 6,
+    //   route: '/leaderboard',
+    //   text: '',
+    //   TabIcon: MdOutlineLeaderboard,
+    // },
+    // Don't need to display leaderboard twice
   ];
 
   const huntingSubMenu = [
@@ -329,7 +330,12 @@ const Header = () => {
           backdropFilter='auto'
           backdropBlur='16px'
         >
-          <HStack spacing={0} pt={{ base: 1, md: 4 }} h='full' w='container.xl'>
+          <HStack
+            spacing={0}
+            pt={{ base: 1, md: 4 }}
+            h='full'
+            w={'container.xl'}
+          >
             <Box
               display={{ base: 'none', md: 'block' }}
               borderBottom='1px'
@@ -363,7 +369,7 @@ const Header = () => {
                   text='More'
                   as={HeaderTab}
                 />
-                <MenuList minW='0' w='160px' fontSize='xs'>
+                <MenuList minW='0' w='160px' fontSize='xl'>
                   {authentication.isLoggedIn ? (
                     <Link to='/profile'>
                       <MenuItem
@@ -454,7 +460,7 @@ const Header = () => {
           px={{ base: 4, md: 8 }}
           h={{ base: '40px', md: '60px' }}
           borderColor={colorMode === 'dark' ? 'gray.300' : 'black'}
-          pt={{ base: '80px', md: '100px' }}
+          pt={{ base: '0', md: '100px' }}
           // visible={huntingSubMenuVisible ? { base: 'hidden', md: 'visible' } : { base: 'hidden', md: 'hidden' }}
           display={huntingSubMenuVisible ? 'inherit' : 'none'}
           alignItems='center'
@@ -468,15 +474,14 @@ const Header = () => {
             >
               <HeaderTab
                 indicatorRef={indicatorElementSubMenu}
-                fontSize={{ base: 'xs', md: 'md', xl: 'l' }}
+                fontSize={{ base: 'xs', md: 'md', xl: 'md' }}
                 {...tab}
               />
             </Box>
           ))}
         </Center>
       </VStack>
-
-      <Box pt={{ base: '16px', md: '120px', xl: '150px' }}>
+      <Box pt={{ base: '16px', md: '120px', xl: '150px' }} align={'center'}>
         <Outlet />
       </Box>
       <Footer />

--- a/src/components/Header/HeaderTab.jsx
+++ b/src/components/Header/HeaderTab.jsx
@@ -107,16 +107,14 @@ const HeaderTab = forwardRef(
           transform: { base: 'translateY(0px)', md: 'translateY(-2px)' },
         }}
         transform={
-          highlight
-            ? {
-                base: 'translateY(0px)',
-                md: 'translateY(-2px)',
-              }
-            : {}
+          highlight && {
+            base: 'translateY(0px)',
+            md: 'translateY(-2px)',
+          }
         }
         bg={highlight ? 'whiteAlpha.200' : null}
         transition='background-color 150ms ease-in-out, transform 150ms ease-in-out'
-        spacing={{ base: 1, xl: 4 }}
+        spacing={{ base: 1, xl: 2 }}
         h='full'
         px={text !== '' ? { base: 2, md: 4, xl: 8 } : { base: 1, md: 2, xl: 4 }}
       >
@@ -197,7 +195,7 @@ HeaderTab.defaultProps = {
   onClick: () => {},
   indicatorRef: null,
   isSpacer: false,
-  fontSize: { base: 'xs', md: 'md', xl: 'xl' },
+  fontSize: { base: 'xs', md: 'md', xl: 'md' },
 };
 
 export default HeaderTab;

--- a/src/components/Header/Theming/BackgroundColors.js
+++ b/src/components/Header/Theming/BackgroundColors.js
@@ -17,6 +17,7 @@ const light = {
   'UranianBlue-Celadon': ['#9be5c3', '#bce6fd'],
   'UranianBlue-Melon': ['#ffbda5', '#bce6fd'],
   'UranianBlue-Plum': ['#e792d3', '#bce6fd'],
+  'UranianYellow-Plum': ['#FFFCCE', '#FFFAA6'],
   'UranianBlue-Vanilla': ['#f5e8a3', '#bce6fd'],
   UranianBlue: ['#bce6fd', '#bce6fd'],
   'Vanilla-Celadon': ['#9be5c3', '#f5e8a3'],
@@ -45,6 +46,7 @@ const dark = {
   'UranianBlue-Celadon': ['#3d7052', '#4d71bf'],
   'UranianBlue-Melon': ['#de4e42', '#4e70b5'],
   'UranianBlue-Plum': ['#713a5e', '#4e6eb5'],
+  'UranianYellow-Plum': ['#0F0E00', '#222000'],
   'UranianBlue-Vanilla': ['#8f7441', '#4e71bc'],
   UranianBlue: ['#4d71c3', '#4d71c3'],
   'Vanilla-Celadon': ['#3e7051', '#887441'],
@@ -64,7 +66,7 @@ export function getCurrentBG() {
     (!Object.keys(light).includes(currentTheme) &&
       !Object.keys(dark).includes(currentTheme))
   ) {
-    localStorage.setItem('chakra-ui-theme', 'Plum-UranianBlue');
+    localStorage.setItem('chakra-ui-theme', 'UranianYellow-Plum');
     localStorage.setItem('chakra-ui-color-mode', 'dark');
   }
 
@@ -82,9 +84,9 @@ export function getBackgrounds() {
 
 export function getDefaultBackgrounds() {
   return {
-    light: [light['Celadon-Melon'][0], light['Celadon-Melon'][1]],
-    dark: [dark['UranianBlue-Plum'][0], dark['UranianBlue-Plum'][1]],
-    lightGradient: `linear-gradient(${light['Celadon-Melon'][0]}, ${light['Celadon-Melon'][1]});`,
-    darkGradient: `linear-gradient(${dark['UranianBlue-Plum'][0]}, ${dark['UranianBlue-Plum'][1]});`,
+    light: [light['UranianYellow-Plum'][0], light['UranianYellow-Plum'][1]],
+    dark: [dark['UranianYellow-Plum'][0], dark['UranianYellow-Plum'][1]],
+    lightGradient: `linear-gradient(${light['UranianYellow-Plum'][0]}, ${light['UranianYellow-Plum'][1]});`,
+    darkGradient: `linear-gradient(${dark['UranianYellow-Plum'][0]}, ${dark['UranianYellow-Plum'][1]});`,
   };
 }

--- a/src/views/Dashboard/HorizontalMinimalCard.jsx
+++ b/src/views/Dashboard/HorizontalMinimalCard.jsx
@@ -18,9 +18,9 @@ import React, { useContext } from 'react';
 import { MdOutlineDns, MdSouth } from 'react-icons/md';
 import { motion } from 'framer-motion';
 
-import { getMapImageUrl } from '../../../../api/api';
-import mapImageFallback from '../../../../assets/images/mapImageFallback.jpg';
-import EventContext from '../../../../context/EventContext';
+import { getMapImageUrl } from '../../api/api';
+import mapImageFallback from '../../assets/images/mapImageFallback.jpg';
+import EventContext from '../../context/EventContext';
 
 // eslint-disable-next-line no-unused-vars
 const HorizontalMinimalCard = ({ serverNumber, maps, timeLimit, timeLeft }) => {

--- a/src/views/Dashboard/OffSeason.jsx
+++ b/src/views/Dashboard/OffSeason.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import {
+  Center,
+  Flex,
+  VStack,
+  HStack,
+  Text,
+  Box,
+  useDisclosure,
+} from '@chakra-ui/react';
+import PlayerCard from './PlayerCard';
+
+const Offseason = () => (
+  <Center maxW='full' h={{ base: '70vh', md: '80vh' }}>
+    <VStack spacing={16} mt={4} mb={20}>
+      <Text
+        fontWeight='500'
+        textShadow='glow'
+        letterSpacing='0.2em'
+        fontSize={{ base: '2xl', md: '5xl' }}
+      >
+        Kacky Reloaded 4
+      </Text>
+      <Flex flexDir={'row'} gap={{ base: 0, md: 20 }}>
+        <PlayerCard name='Skandear' rank={2} fins={65} avg={41.1} />
+        <PlayerCard name='Tekky' rank={1} fins={69} avg={40.5} />
+        <PlayerCard name='Dazzzyy' rank={3} fins={63} avg={60.8} />
+      </Flex>
+      <Text
+        mt={{ base: 0, md: 100 }}
+        fontSize={{ base: 'md', md: 'xl' }}
+        textTransform='none'
+        px={4}
+      >
+        Better get training so your name is here next time!
+        <br />
+        Join the Kacky Servers in Trackmania Nations Forever or the &quot;Kacky
+        Reloaded&quot; Club in Trackmania 2020!
+      </Text>
+    </VStack>
+  </Center>
+);
+
+export default Offseason;

--- a/src/views/Dashboard/PlayerCard.jsx
+++ b/src/views/Dashboard/PlayerCard.jsx
@@ -1,0 +1,49 @@
+import { Flex, Text } from '@chakra-ui/react';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const PlayerCard = ({ name, rank, fins, avg }) => {
+  let rankcolor = '#000000';
+  let medal = '';
+  if (rank === 1) {
+    rankcolor = '#FFD700';
+    medal = '🥇';
+  }
+  if (rank === 2) {
+    rankcolor = '#C0C0C0';
+    medal = '🥈';
+  }
+  if (rank === 3) {
+    rankcolor = '#CD7F32';
+    medal = '🥉';
+  }
+
+  return (
+    <Flex
+      flexDir={'column'}
+      marginTop={(rank - 1) * 5}
+      width={{ base: 115, md: 160 }}
+    >
+      <Text
+        fontSize={rank === 1 ? 30 : 25}
+        color={rankcolor}
+        whiteSpace={{ base: 'pre-line', md: 'unset' }}
+      >
+        {medal}
+        {'\n'}
+        {name}
+      </Text>
+      <Text fontSize='lg'>Fins: {fins}</Text>
+      <Text fontSize='lg'>Average: {avg}</Text>
+    </Flex>
+  );
+};
+
+PlayerCard.propTypes = {
+  name: PropTypes.string.isRequired,
+  rank: PropTypes.number.isRequired,
+  fins: PropTypes.number.isRequired,
+  avg: PropTypes.number.isRequired,
+};
+
+export default PlayerCard;

--- a/src/views/Dashboard/ServerCard.jsx
+++ b/src/views/Dashboard/ServerCard.jsx
@@ -15,6 +15,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import React, { useContext } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
 import { DateTime } from 'luxon';
 import { MdOutlineCheckCircle } from 'react-icons/md';
 import MapImageModal from '../../components/MapImageModal';
@@ -62,10 +63,11 @@ const ServerCard = ({
         event.type,
         maps[0].number
       )}), url(${mapImageFallback})`}
+      bgColor='black'
       bgPosition='center'
       bgRepeat='no-repeat'
       bgSize='cover'
-      h={{ base: 'column', xl: 32 }}
+      position='relative'
     >
       <Box
         w='full'
@@ -74,7 +76,7 @@ const ServerCard = ({
           colorMode === 'dark'
             ? getDefaultBackgrounds().dark[1]
             : getDefaultBackgrounds().light[1]
-        }11`}
+        }75`}
       >
         <Center
           px={{ base: 4, md: 8 }}
@@ -98,7 +100,7 @@ const ServerCard = ({
               colorMode === 'dark'
                 ? getDefaultBackgrounds().dark[1]
                 : getDefaultBackgrounds().light[1]
-            }80 5560%,  ${
+            }80 55%,  ${
               colorMode === 'dark'
                 ? getDefaultBackgrounds().dark[0]
                 : getDefaultBackgrounds().light[0]
@@ -119,22 +121,25 @@ const ServerCard = ({
           }}
         >
           <Flex
-            direction={{ base: 'column', xl: 'row' }}
-            align={{ base: 'flex-start', xl: 'center' }}
-            pl={{ base: 8, sm: 16, xl: 0 }}
-            py={8}
-            gap={{ base: 8, xl: 0 }}
-            justify='space-between'
+            direction={{ base: 'column', md: 'row', xl: 'row' }}
+            align={{ base: 'center' }}
+            // pl={{ base: 8, sm: 16, xl: 0 }}
+            py={{ base: 8, lg: 2 }}
+            gap={{ base: 8 }}
+            justify={('center', 'space-between')}
             w='container.xl'
           >
             {/* SERVER */}
-            <HStack w='220px' spacing={4}>
+            <HStack
+              spacing={4}
+              alignItems={['center']}
+              justifyContent={{ base: 'center', xl: 'start' }}
+            >
               <Text textShadow='glow' w='85px' fontSize='5xl' lineHeight='48px'>
                 # {serverNumber}
               </Text>
               {serverDifficulty !== '' ? ( // Servers do not have a difficulty in Phase 1
                 <Badge
-                  width={'5rem'}
                   fontSize={'xl'}
                   visibility={
                     serverDifficulty === 'undefined' ? 'hidden' : 'visible'
@@ -152,10 +157,11 @@ const ServerCard = ({
 
             {/* MAP NUMBER */}
             <HStack
-              w='320px'
+              px={4}
               onClick={onOpen}
               cursor='pointer'
               _hover={{ transform: 'scale(1.05)' }}
+              transition='transform 0.1s ease-in-out'
             >
               <Text
                 fontSize='2xl'
@@ -196,114 +202,140 @@ const ServerCard = ({
             </HStack>
 
             {/* NEXT MAPS */}
-            <Flex direction='row' gap={2} w='120px'>
-              <Flex
-                h='88px'
-                direction='column'
-                spacing={0}
-                justify='stretch'
-                align='center'
-              >
-                <Box
-                  bg={colorMode === 'dark' ? 'white' : 'black'}
-                  w='2px'
-                  h='full'
-                  boxShadow='glow'
-                />
-                <Box
-                  filter={
-                    colorMode === 'dark' ? theme.shadows.dropGlow : 'none'
-                  }
-                >
-                  <svg
-                    fill={colorMode === 'dark' ? 'white' : 'black'}
-                    height='12px'
-                    width='12px'
-                  >
-                    <polygon points='0,0 12,0 6,12' />
-                  </svg>
-                </Box>
-              </Flex>
-              <Flex direction='column' align='flex-start' gap={2}>
-                {maps.slice(1).map((map, index) => (
-                  <HStack
-                    onClick={nextMapModals[index].onOpen}
-                    cursor='pointer'
-                    w='100%'
-                    justify='flex-start'
-                    _hover={{ transform: 'scale(1.05)' }}
-                    spacing={1}
-                    key={map.number}
-                  >
-                    <Text
-                      lineHeight='24px'
-                      fontWeight={nextMapsFontWeight[index]}
-                      fontSize='2xl'
-                      letterSpacing='0.1em'
-                      textShadow='glow'
-                      w='100%'
-                    >
-                      {map.number}
-                    </Text>
-                    {map.finished ? (
-                      <Icon
-                        color={colorMode === 'dark' ? 'green.300' : 'green.500'}
-                        boxSize='20px'
-                        filter={
-                          colorMode === 'dark'
-                            ? theme.shadows.finGlowDark
-                            : theme.shadows.finGlowLight
-                        }
-                        as={MdOutlineCheckCircle}
-                      />
-                    ) : null}
-                    <MapImageModal
-                      mapNumber={map.number.toString()}
-                      author={map.author}
-                      isFinished={map.finished}
-                      isOpen={nextMapModals[index].isOpen}
-                      onClose={nextMapModals[index].onClose}
-                      eventtype={event.type}
-                    />
-                  </HStack>
-                ))}
-              </Flex>
-            </Flex>
-
-            {/* TIME LEFT */}
-            <Flex justify='center' align='center'>
-              {timeLeft <= 0 ? (
-                <Text
+            <Flex
+              direction={'row'}
+              justify='end'
+              align='center'
+              gap={{ base: '2', md: '4', lg: '10', xl: '10' }}
+            >
+              <Flex direction='row' spacing={0} gap={2}>
+                <Flex
+                  h='88px'
+                  direction='column'
+                  spacing={0}
+                  justify='stretch'
                   align='center'
-                  width='114px'
-                  ml={4}
-                  color='red.500'
-                  _dark={{ color: 'red.300' }}
-                  fontWeight='normal'
-                  fontSize='md'
-                  letterSpacing='0.1em'
-                  m={0}
                 >
-                  Switching to next Map
-                </Text>
-              ) : (
-                <CircularProgress
-                  trackColor='transparent'
-                  thickness='2px'
-                  color={colorMode === 'dark' ? 'white' : 'black'}
-                  value={(timeLeft / timeLimit) * 100}
-                  size='114px'
-                >
-                  <CircularProgressLabel
-                    fontWeight='semilight'
-                    fontSize='2xl'
-                    letterSpacing='0.1em'
-                    sx={{ fontVariantNumeric: 'tabular-nums' }}
+                  <Box
+                    bg={colorMode === 'dark' ? 'white' : 'black'}
+                    w='2px'
+                    h='full'
+                    boxShadow='glow'
+                  />
+                  <Box
+                    filter={
+                      colorMode === 'dark' ? theme.shadows.dropGlow : 'none'
+                    }
                   >
-                    {DateTime.fromSeconds(timeLeft).toFormat('mm:ss')}
-                  </CircularProgressLabel>
-                </CircularProgress>
-              )}
+                    <svg
+                      fill={colorMode === 'dark' ? 'white' : 'black'}
+                      height='12px'
+                      width='12px'
+                    >
+                      <polygon points='0,0 12,0 6,12' />
+                    </svg>
+                  </Box>
+                </Flex>
+                <Flex direction='column' align='flex-start' gap={2}>
+                  {maps.slice(1).map((map, index) => (
+                    <HStack
+                      onClick={nextMapModals[index].onOpen}
+                      cursor='pointer'
+                      w='100%'
+                      justify='flex-start'
+                      _hover={{ transform: 'scale(1.05)' }}
+                      transition='transform 0.1s ease-in-out'
+                      spacing={1}
+                      key={map.number}
+                    >
+                      <Text
+                        lineHeight='24px'
+                        fontWeight={nextMapsFontWeight[index]}
+                        fontSize='2xl'
+                        letterSpacing='0.1em'
+                        textShadow='glow'
+                        w='100%'
+                      >
+                        {map.number}
+                      </Text>
+                      {map.finished ? (
+                        <Icon
+                          color={
+                            colorMode === 'dark' ? 'green.300' : 'green.500'
+                          }
+                          boxSize='20px'
+                          filter={
+                            colorMode === 'dark'
+                              ? theme.shadows.finGlowDark
+                              : theme.shadows.finGlowLight
+                          }
+                          as={MdOutlineCheckCircle}
+                        />
+                      ) : null}
+                      <MapImageModal
+                        mapNumber={map.number.toString()}
+                        author={map.author}
+                        isFinished={map.finished}
+                        isOpen={nextMapModals[index].isOpen}
+                        onClose={nextMapModals[index].onClose}
+                        eventtype={event.type}
+                      />
+                    </HStack>
+                  ))}
+                </Flex>
+              </Flex>
+              {/* TIME LEFT */}
+              <Flex justify='center' align='center' h='7rem' w='7rem'>
+                <AnimatePresence>
+                  {timeLeft <= 0 ? (
+                    <motion.div
+                      key='loading'
+                      initial={{ opacity: 0, scale: 1.1, position: 'absolute' }} // Start slightly enlarged
+                      animate={{ opacity: 1, scale: 1, position: 'absolute' }} // Animate layout changes
+                      exit={{ opacity: 0, scale: 0.9, position: 'absolute' }} // End slightly smaller
+                      transition={{ duration: 0.5 }}
+                    >
+                      <Text
+                        align='center'
+                        width='114px'
+                        color='red.500'
+                        _dark={{ color: 'red.300' }}
+                        fontWeight='bold'
+                        fontSize={{ base: 'xl', md: 'xl', xl: 'lg' }}
+                        letterSpacing='0.1em'
+                        m={0}
+                      >
+                        Loading next Map
+                      </Text>
+                    </motion.div>
+                  ) : (
+                    <motion.div
+                      key='timer'
+                      initial={{ opacity: 0, scale: 0.9, position: 'absolute' }} // Start slightly shrunk
+                      animate={{ opacity: 1, scale: 1, position: 'absolute' }}
+                      exit={{ opacity: 0, scale: 1.1, position: 'absolute' }} // End slightly enlarged
+                      transition={{ duration: 0.5 }}
+                    >
+                      <CircularProgress
+                        trackColor='transparent'
+                        thickness='2px'
+                        color={colorMode === 'dark' ? 'white' : 'black'}
+                        value={(timeLeft / timeLimit) * 100}
+                        size='114px'
+                      >
+                        <CircularProgressLabel
+                          fontWeight='semilight'
+                          fontSize='2xl'
+                          letterSpacing='0.1em'
+                          sx={{ fontVariantNumeric: 'tabular-nums' }}
+                        >
+                          {DateTime.fromSeconds(timeLeft).toFormat('mm:ss')}
+                        </CircularProgressLabel>
+                      </CircularProgress>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </Flex>
             </Flex>
           </Flex>
         </Center>

--- a/src/views/Glance/Layouts/HorizontalMinimalGlanceLayout.jsx
+++ b/src/views/Glance/Layouts/HorizontalMinimalGlanceLayout.jsx
@@ -27,8 +27,14 @@ HorizontalMinimalGlanceLayout.propTypes = {
   servers: PropTypes.arrayOf(
     PropTypes.shape({
       serverNumber: PropTypes.string,
-      maps: PropTypes.arrayOf(PropTypes.number),
-      serverDifficulty: PropTypes.number,
+      maps: PropTypes.arrayOf(
+        PropTypes.shape({
+          number: PropTypes.number.isRequired,
+          author: PropTypes.string.isRequired,
+          finished: PropTypes.bool.isRequired,
+        })
+      ),
+      serverDifficulty: PropTypes.string, // Change expected type to string
       timeLimit: PropTypes.number,
     })
   ).isRequired,

--- a/src/views/Glance/Layouts/VerticalGlanceLayout.jsx
+++ b/src/views/Glance/Layouts/VerticalGlanceLayout.jsx
@@ -25,8 +25,14 @@ VerticalGlanceLayout.propTypes = {
   servers: PropTypes.arrayOf(
     PropTypes.shape({
       serverNumber: PropTypes.string,
-      maps: PropTypes.arrayOf(PropTypes.number),
-      serverDifficulty: PropTypes.number,
+      maps: PropTypes.arrayOf(
+        PropTypes.shape({
+          number: PropTypes.number.isRequired,
+          author: PropTypes.string.isRequired,
+          finished: PropTypes.bool.isRequired,
+        })
+      ),
+      serverDifficulty: PropTypes.string, // Change expected type to string
       timeLimit: PropTypes.number,
     })
   ).isRequired,

--- a/src/views/Glance/Layouts/VerticalMinimalGlanceLayout.jsx
+++ b/src/views/Glance/Layouts/VerticalMinimalGlanceLayout.jsx
@@ -1,27 +1,29 @@
-import { HStack } from '@chakra-ui/react';
+import { Center, HStack } from '@chakra-ui/react';
 import React from 'react';
 import PropTypes from 'prop-types';
-import HotbarCard from './components/HotbarCard';
+import VerticalMinimalCard from './components/VerticalMinimalCard';
 
-const HorizontalGlanceLayout = ({
+const VerticalMinimalGlanceLayout = ({
   servers,
   counter,
   mapChangeEstimate,
   elemSpacing,
 }) => (
-  <HStack spacing={elemSpacing} justify='center'>
-    {servers.map((server, index) => (
-      <HotbarCard
-        {...server}
-        timeLeft={counter[index] - mapChangeEstimate}
-        key={server.serverNumber}
-        style={{ transition: 'opacity 1s' }}
-      />
-    ))}
-  </HStack>
+  <Center>
+    <HStack spacing={elemSpacing}>
+      {servers.map((server, index) => (
+        <VerticalMinimalCard
+          {...server}
+          timeLeft={counter[index] - mapChangeEstimate}
+          key={server.serverNumber}
+          style={{ transition: 'opacity 1s' }}
+        />
+      ))}
+    </HStack>
+  </Center>
 );
 
-HorizontalGlanceLayout.propTypes = {
+VerticalMinimalGlanceLayout.propTypes = {
   servers: PropTypes.arrayOf(
     PropTypes.shape({
       serverNumber: PropTypes.string,
@@ -41,4 +43,4 @@ HorizontalGlanceLayout.propTypes = {
   elemSpacing: PropTypes.number.isRequired,
 };
 
-export default HorizontalGlanceLayout;
+export default VerticalMinimalGlanceLayout;

--- a/src/views/Glance/Layouts/components/VerticalMinimalCard.jsx
+++ b/src/views/Glance/Layouts/components/VerticalMinimalCard.jsx
@@ -1,0 +1,147 @@
+import PropTypes from 'prop-types';
+
+import {
+  Center,
+  Box,
+  useColorMode,
+  Flex,
+  HStack,
+  Text,
+  Icon,
+  useTheme,
+  VStack,
+} from '@chakra-ui/react';
+import React, { useContext } from 'react';
+import { MdOutlineDns, MdSouth } from 'react-icons/md';
+
+import { getMapImageUrl } from '../../../../api/api';
+import mapImageFallback from '../../../../assets/images/mapImageFallback.jpg';
+import EventContext from '../../../../context/EventContext';
+
+// eslint-disable-next-line no-unused-vars
+const VerticalMinimalCard = ({ serverNumber, maps, timeLimit, timeLeft }) => {
+  const theme = useTheme();
+  const { colorMode } = useColorMode();
+
+  const { event } = useContext(EventContext);
+
+  return (
+    <Box
+      bgImage={`url(${getMapImageUrl(
+        event.type,
+        maps[0].number
+      )}), url(${mapImageFallback})`}
+      bgPosition='center'
+      bgRepeat='no-repeat'
+      bgSize='cover'
+      w='100px'
+      h='175px'
+      bgColor={
+        colorMode === 'dark' ? 'rgba(255,255,255,0.05)' : 'rgba(6,6,6,0.05)'
+      }
+    >
+      <Center
+        px={{ base: 4, md: 8 }}
+        w='full'
+        h='full'
+        bgGradient={{
+          base: `linear(to-r, background 0%, ${
+            colorMode === 'dark' ? 'blackAlpha.800 40%' : 'whiteAlpha.900 40%'
+          },  ${
+            colorMode === 'dark' ? 'blackAlpha.600 100%' : 'whiteAlpha.700 100%'
+          })`,
+          md: `linear(to-r, background 0%, ${
+            colorMode === 'dark' ? 'blackAlpha.800 40%' : 'whiteAlpha.900 40%'
+          },  transparent 100%)`,
+          xl: `linear(to-r, background, ${
+            colorMode === 'dark' ? 'rgba(6,6,6,0.8)' : 'rgba(255,255,255,0.8)'
+          }, background)`,
+        }}
+      >
+        <Flex direction='column' align='center' justify='center'>
+          {/* SERVER */}
+          <HStack spacing={1}>
+            <Icon
+              filter={colorMode === 'dark' ? theme.shadows.dropGlow : 'none'}
+              fontSize={22}
+              as={MdOutlineDns}
+            />
+            <Text fontSize='xl'>{serverNumber}</Text>
+          </HStack>
+          {/* NEXT MAPS */}
+          <Box marginTop={2}>
+            <VStack direction='row' align='flex-start' gap='5px'>
+              <VStack w='auto' justify='center'>
+                <Text
+                  lineHeight='24px'
+                  fontSize='2xl'
+                  fontWeight='medium'
+                  letterSpacing='0.1em'
+                  color={
+                    maps[0].finished
+                      ? colorMode === 'dark'
+                        ? 'green.300'
+                        : 'green.500'
+                      : ''
+                  }
+                >
+                  {maps[0].number}
+                </Text>
+                <Icon
+                  boxSize={5}
+                  filter={
+                    colorMode === 'dark' ? theme.shadows.dropGlow : 'none'
+                  }
+                  as={MdSouth}
+                />
+                <Text
+                  lineHeight='24px'
+                  fontSize='2xl'
+                  fontWeight='medium'
+                  letterSpacing='0.1em'
+                  color={
+                    maps[1].finished
+                      ? colorMode === 'dark'
+                        ? 'green.300'
+                        : 'green.500'
+                      : ''
+                  }
+                >
+                  {maps[1].number}
+                </Text>
+              </VStack>
+            </VStack>
+          </Box>
+          <Text pt={2}>
+            {timeLeft > 0
+              ? Math.floor(timeLeft / 60)
+                  .toString()
+                  .padStart(2, '0')
+              : '00'}
+            :
+            {timeLeft > 0
+              ? Math.floor(timeLeft % 60)
+                  .toString()
+                  .padStart(2, '0')
+              : '00'}
+          </Text>
+        </Flex>
+      </Center>
+    </Box>
+  );
+};
+
+VerticalMinimalCard.propTypes = {
+  serverNumber: PropTypes.string.isRequired,
+  maps: PropTypes.arrayOf(
+    PropTypes.shape({
+      number: PropTypes.number,
+      finished: PropTypes.bool,
+      author: PropTypes.string,
+    })
+  ).isRequired,
+  timeLimit: PropTypes.number.isRequired,
+  timeLeft: PropTypes.number.isRequired,
+};
+
+export default VerticalMinimalCard;

--- a/src/views/Profile/Profile.jsx
+++ b/src/views/Profile/Profile.jsx
@@ -20,6 +20,7 @@ import {
   AlertDialogFooter,
   AlertDialog,
   useDisclosure,
+  Flex,
 } from '@chakra-ui/react';
 
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -176,7 +177,12 @@ const Profile = () => {
 
   return (
     <Center px={8} w='100%'>
-      <VStack spacing={6} align='flex-start' w='container.xl'>
+      <Flex
+        gap={6}
+        direction={{ base: 'column' }}
+        align='center'
+        w='container.xl'
+      >
         {admin ? (
           <Button as={Link} href='/kackend'>
             Admin Backend
@@ -383,7 +389,7 @@ const Profile = () => {
             </AlertDialogOverlay>
           </AlertDialog>
         </HStack>
-      </VStack>
+      </Flex>
     </Center>
   );
 };


### PR DESCRIPTION
Addressed issues:
#39
#50
#51

UI
Added ugly-green variant of dark theme in random place of theme files and set it as default
'UranianYellow-Plum': ['#0F0E00', '#222000']

Dashboard
Fixed dashboard ui for all sizes and moved from grid to flex one column
Added filter tabs by server difficulty with lazy loading - this will probably crash on Phase 1, might need some adjustments and testing
Added isLoading checks for proper ui rendering
Implemented framer-motion on initial load
Added swap fade in - fade out animations for timer <-> Loading next map

Header
Fixed ui shift. fontSize xl -> md, otherwise it shifts header outside boundaries to the right